### PR TITLE
Fix CONTRIBUTING link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This documentation covers the instructions how to install Valkey from Percona pa
 
 ## Contributing
 
-For how to contribute to documentation, read the [Contributing guide](https://github.com/percona/percona-valkey-doc/main/CONTRIBUTING.md).
+For how to contribute to documentation, read the [Contributing guide](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
The link wasn't working. Removed the full path and left only the page name. The CONTRIBUTING page is in the same directory of the README file.