### PR TITLE
Release Notes for v8.1.0 GA

### DIFF
--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -1,0 +1,22 @@
+# Valkey 8.1.0 release notes
+
+--8<-- "upgrade-urgency.md"
+
+## Valkey 8.1.0 GA - Released Mon 31 March 2025
+
+Upgrade urgency **LOW**.
+
+This is the first release of Valkey 8.1, with a minor version update designed to further enhance performance, reliability, observability and usability over Valkey 8.0 for all Valkey installations.
+
+This release is fully compatible with all previous Valkey releases as well as Redis OSS 7.2.4.
+
+### Behavior Changes
+
+Hide input buffer data from being logged on protocol error when hide-user-data-from-log is enabled ([#1889])
+
+### Bug fixes
+
+Fix a bug in `VM_GetCurrentUserName` which leads to engine crash when no valid username provided ([#1885])
+
+[#1889]: https://github.com/valkey-io/valkey/pull/1889
+[#1885]: https://github.com/valkey-io/valkey/pull/1885

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -6,6 +6,7 @@ Find the list of changes introduced in the Percona packages for Valkey below.
 
 ## Version 8.1.x
 
+* [8.1.0](8.1.0.md)
 * [8.1.0 RC2](8.1.0-rc2.md)
 * [8.1.0 RC1](8.1.0-rc1.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,7 @@ nav:
   - Release notes:
     - "Release notes index": release-notes/release-notes.md
     - 8.1.x:
+      - "8.1.0": release-notes/8.1.0.md
       - "8.1.0 RC2": release-notes/8.1.0-rc2.md
       - "8.1.0 RC1": release-notes/8.1.0-rc1.md
     - 8.0.x:


### PR DESCRIPTION
Added new release note and linked it in mkdocs yml, populated with release content from upstream valkey, linked release note to release note index.