### PR TITLE
DOCS-346 - Remove leftover experimental for packages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,16 +4,11 @@ Welcome to Percona Packages for Valkey documentation!
 
 This is the set of tutorials to help you get started with Valkey. You will find instructions of how to install Valkey from Percona packages and how to migrate from a Redis to a Valkey server.
 
-!!! warning
-    **Experimental software - not for production use**
-
-    Percona Valkey packages are currently provided through the **experimental** repository. These packages have **not** completed full QA validation and are **not** recommended for production environments.
-
 <div data-grid markdown><div data-banner markdown>
 
 ## :material-progress-download: Installation guide { .title }
 
-Install and evaluate Valkey using Percona experimental packages.
+Install and evaluate Valkey using Percona packages.
 
 [Install Valkey :material-arrow-right:](installation.md){ .md-button }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,13 +4,6 @@ Valkey offers packages for a select number of Linux distributions. Specifically,
 
 To support Valkey’s development and adoption, Percona provides packages for all major active Linux distributions, making it easy for you to install Valkey on your system.
 
-!!! warning
-    **Experimental packages - not for production use**
-
-    Percona Valkey packages are currently provided through the **experimental** repository. These packages have **not** completed full QA validation and are **not** recommended for production environments.
-
-    Use them only for development, testing, evaluation, or non-critical workloads.
-
 The packages are available for both x86_64 and ARM64 architectures for the following operating systems:
 
 * Oracle Linux 8, Rocky Linux 8 and Alma Linux 8


### PR DESCRIPTION
This PR removes the remaining experimental package warnings, as valkey 91 release is stable.